### PR TITLE
As per my email, here's my performance work on the chunked algorithm. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ walk
 # Data files
 *.dat
 OC
+
+# VSCode files
+**/.vscode
+

--- a/walk.bitstat5/BitStorage.cpp
+++ b/walk.bitstat5/BitStorage.cpp
@@ -1,8 +1,16 @@
 #include "BitStorage.h"
 #include <immintrin.h> // For AVX-512 intrinsics
+#include <string.h>
+
+size_t alignedByteSize(size_t bitSize) {
+    return (bitSize + 511) / 512 * 64;
+}
 
 BitStorage::BitStorage(size_t bitSize)
-    : storage((uint64_t*) aligned_alloc(64, (bitSize + 511) / 512 * 64)), storage_size(0) {}
+    // Alloc 512 bit aligned blocks, aligned to 64 byte page size
+    : storage((uint64_t*) aligned_alloc(64, alignedByteSize(bitSize))), storage_size(bitSize) {
+
+    }
 
 BitStorage::~BitStorage() {
     free(this->storage);
@@ -10,8 +18,8 @@ BitStorage::~BitStorage() {
 
 BitStorage BitStorage::clone() const
 {
-    BitStorage copy(this->storage_size * 64);
-    copy.storage = storage;
+    BitStorage copy(this->storage_size);
+    memcpy(copy.storage, this->storage, alignedByteSize(this->storage_size));
     return copy;
 }
 

--- a/walk.bitstat5/BitStorage.cpp
+++ b/walk.bitstat5/BitStorage.cpp
@@ -3,13 +3,14 @@
 #include <string.h>
 #include <assert.h>
 
-size_t alignedByteSize(size_t bitSize) {
-    return (bitSize + 511) / 512 * 64;
+size_t alignTo(size_t value, size_t align) {
+    return (value + align - 1) / align * align;
 }
 
 BitStorage::BitStorage(size_t bitSize)
-    // Alloc 512 bit aligned blocks, aligned to 64 byte page size
-    : storage((uint64_t*) aligned_alloc(64, alignedByteSize(bitSize))), storage_size(alignedByteSize(bitSize) / sizeof(uint64_t)) {
+    // Alloc aligned 2048 byte blocks, aligned to 64 byte page size
+    // This allocates more memory than strictly needed, but it simplifies code that uses these bitsets
+    : storage((uint64_t*) aligned_alloc(64, alignTo(bitSize, 8*ALLOC_SIZE_ALIGN) / 8)), storage_size(alignTo(bitSize, 8*64) / 8 / sizeof(uint64_t)) {
 
     }
 

--- a/walk.bitstat5/BitStorage.h
+++ b/walk.bitstat5/BitStorage.h
@@ -29,6 +29,7 @@ class BitStorage
 public:
     // Constructor to initialize storage with a given number of bits
     BitStorage(size_t bitSize);
+    ~BitStorage();
 
     // Clone method to create a deep copy of the object
     BitStorage clone() const;
@@ -58,7 +59,8 @@ public:
     size_t size() const;
 
 private:
-    std::vector<uint64_t> storage; // Stores bits in 64-bit chunks
+    alignas(64) uint64_t* storage; // Stores bits in 64-bit chunks
+    size_t storage_size;
 };
 
 #endif // BITSTORAGE_H

--- a/walk.bitstat5/BitStorage.h
+++ b/walk.bitstat5/BitStorage.h
@@ -31,6 +31,11 @@ public:
     BitStorage(size_t bitSize);
     ~BitStorage();
 
+    BitStorage(const BitStorage&) = delete;
+    BitStorage& operator=(const BitStorage&) = delete;
+    BitStorage(BitStorage&&) noexcept;
+    BitStorage& operator=(BitStorage&&) noexcept;
+
     // Clone method to create a deep copy of the object
     BitStorage clone() const;
 

--- a/walk.bitstat5/BitStorage.h
+++ b/walk.bitstat5/BitStorage.h
@@ -27,6 +27,11 @@ static inline __m512i popcount512_64(__m512i v) {
 class BitStorage
 {
 public:
+    static const size_t ALLOC_SIZE_ALIGN = 2048;
+    
+    alignas(64) uint64_t* storage; // Stores bits in 64-bit chunks
+    size_t storage_size;
+public:
     // Constructor to initialize storage with a given number of bits
     BitStorage(size_t bitSize);
     ~BitStorage();
@@ -63,9 +68,6 @@ public:
     // Get the size of the data in 64-bit words
     size_t size() const;
 
-private:
-    alignas(64) uint64_t* storage; // Stores bits in 64-bit chunks
-    size_t storage_size;
 };
 
 #endif // BITSTORAGE_H

--- a/walk.bitstat5/BitStorage.h
+++ b/walk.bitstat5/BitStorage.h
@@ -5,6 +5,25 @@
 #include <cstdint>
 #include <stdexcept>
 #include <immintrin.h> // For AVX-512 intrinsics
+
+
+#ifdef __AVX512VPOPCNTDQ__
+#define popcount512_64 _mm512_popcnt_epi64
+#else
+static inline __m512i popcount512_64(__m512i v) {
+    alignas(64) u_int64_t vv[8];
+    _mm512_store_epi64(static_cast<void*>(vv), v);
+
+    for(int i = 0; i < 8; i++) {
+        vv[i] = __builtin_popcountll(vv[i]);
+    }
+
+    return _mm512_load_epi64(static_cast<const void*>(vv));
+}
+#endif
+
+
+
 class BitStorage
 {
 public:

--- a/walk.bitstat5/FastCompare.cpp
+++ b/walk.bitstat5/FastCompare.cpp
@@ -1,0 +1,17 @@
+
+#include "FastCompare.h"
+
+FastCompare::FastCompare(std::vector<MonotoneBooleanFunction>& mbfList, size_t list_size) {
+    endPoints.reserve(list_size);
+    for (size_t ls = 0; ls < list_size; ls++)
+    {
+        ShortList sl = mbfList[ls].getMinCNF();
+
+        for(size_t i = 0; i < sl.getSize(); i++) {
+            leftIndices.push_back(sl.getValue(i));
+        }
+        endPoints.push_back(leftIndices.size());
+    }
+
+    std::cout << "endPoints.size(): " << endPoints.size() << "   leftIndices.size(): " << leftIndices.size() << std::endl;
+}

--- a/walk.bitstat5/FastCompare.h
+++ b/walk.bitstat5/FastCompare.h
@@ -1,0 +1,74 @@
+
+#include <vector>
+#include <stdint.h>
+#include "MonotoneBooleanFunction.h"
+#include "BitStorage.h"
+#include <immintrin.h> // For AVX-512 intrinsics
+#include <iostream>
+#include <chrono>
+
+class FastCompare {
+    std::vector<int16_t> leftIndices;
+    std::vector<size_t> endPoints;
+
+public:
+    FastCompare(std::vector<MonotoneBooleanFunction>& mbfList, size_t list_size);
+
+    template<size_t ChunkSize>
+    void countCompareTo(std::vector<BitStorage>& bitStorage) const {
+        if(BitStorage::ALLOC_SIZE_ALIGN % (ChunkSize*sizeof(uint64_t)) != 0) {throw "Invalid List Size";}
+
+        auto start_at = std::chrono::high_resolution_clock::now();
+
+        int total = 0;
+
+        size_t storage_size = bitStorage[0].storage_size;
+        for (size_t chunkStart = 0; chunkStart < storage_size; chunkStart += ChunkSize)
+        {
+            size_t curIndex = 0;
+            for(size_t endPoint : endPoints) {
+                if constexpr(ChunkSize >= 8) {
+                    alignas(64) __m512i chunkTMP[ChunkSize / 8];
+
+                    const BitStorage& firstBitset = bitStorage[leftIndices[curIndex]];
+                    for(size_t i = 0; i < ChunkSize / 8; i++) {
+                        chunkTMP[i] = _mm512_load_epi64(&firstBitset.storage[chunkStart + 8*i]);
+                    }
+                    while(++curIndex < endPoint) {
+                        const BitStorage& selectedBitset = bitStorage[leftIndices[curIndex]];
+                        for(size_t i = 0; i < ChunkSize / 8; i++) {
+                            chunkTMP[i] = _mm512_and_si512(chunkTMP[i], _mm512_load_epi64(&selectedBitset.storage[chunkStart + 8*i]));
+                        }
+                    };
+
+                    __m512i totals = popcount512_64(chunkTMP[0]);
+                    for(size_t i = 1; i < ChunkSize / 8; i++) {
+                        __m512i subTotal = popcount512_64(chunkTMP[i]);
+                        totals = _mm512_add_epi64(totals, subTotal);
+                    }
+                    total += _mm512_reduce_add_epi64(totals);
+                } else {
+                    alignas(64) uint64_t chunkTMP[ChunkSize];
+
+                    const BitStorage& firstBitset = bitStorage[leftIndices[curIndex]];
+                    for(size_t i = 0; i < ChunkSize; i++) {
+                        chunkTMP[i] = firstBitset.storage[chunkStart + i];
+                    }
+                    while(++curIndex < endPoint) {
+                        const BitStorage& selectedBitset = bitStorage[leftIndices[curIndex]];
+                        for(size_t i = 0; i < ChunkSize; i++) {
+                            chunkTMP[i] &= selectedBitset.storage[chunkStart + i];
+                        }
+                    };
+
+                    for(uint64_t& v : chunkTMP) {
+                        total += __builtin_popcountll(v);
+                    }
+                }
+            }
+        }
+        auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_at).count();
+        std::cout << "ChunkSize: " << ChunkSize << "  total: " << total << "  time: " << millis << std::endl;
+    }
+};
+

--- a/walk.bitstat5/Makefile
+++ b/walk.bitstat5/Makefile
@@ -2,7 +2,7 @@
 CXX = g++
 
 # Compiler flags
-CXXFLAGS = -std=c++17 -Wall -Wextra -g -mavx512f -march=native -O3
+CXXFLAGS = -std=c++17 -Wall -Wextra -g -mavx512f -march=native -O0
 
 # Source files
 SRCS = $(wildcard *.cpp)

--- a/walk.bitstat5/Makefile
+++ b/walk.bitstat5/Makefile
@@ -2,7 +2,7 @@
 CXX = g++
 
 # Compiler flags
-CXXFLAGS = -std=c++17 -Wall -Wextra -g -O3 -march=native -mavx512f
+CXXFLAGS = -std=c++17 -Wall -Wextra -g -march=native -mavx512f -O3 -DNDEBUG
 
 # Source files
 SRCS = $(wildcard *.cpp)

--- a/walk.bitstat5/Makefile
+++ b/walk.bitstat5/Makefile
@@ -2,7 +2,7 @@
 CXX = g++
 
 # Compiler flags
-CXXFLAGS = -std=c++17 -Wall -Wextra -g -mavx512f -march=native -O0
+CXXFLAGS = -std=c++17 -Wall -Wextra -g -O3 -march=native -mavx512f
 
 # Source files
 SRCS = $(wildcard *.cpp)

--- a/walk.bitstat5/MonotoneBooleanFunction.cpp
+++ b/walk.bitstat5/MonotoneBooleanFunction.cpp
@@ -134,14 +134,14 @@ void MonotoneBooleanFunction::toRecord(Record &r)
     }
 }
 
-ShortList *MonotoneBooleanFunction::getMinCNF()
+ShortList MonotoneBooleanFunction::getMinCNF()
 {
-    ShortList *result = new ShortList();    
+    ShortList result;    
     for (int i = 0; i < min_cuts.getSize(); i++)
     {
         int element = min_cuts.getValue(i);
         if (functionArray[element])
-            result->insert(element);
+            result.insert(element);
     }
     return result;
 }

--- a/walk.bitstat5/MonotoneBooleanFunction.cpp
+++ b/walk.bitstat5/MonotoneBooleanFunction.cpp
@@ -78,7 +78,7 @@ void MonotoneBooleanFunction::updateMinCuts()
         }
         else
         {
-            min_cuts.remove(i);
+            min_cuts.remove_if_exists(i);
         }
     }
 }
@@ -94,7 +94,7 @@ void MonotoneBooleanFunction::updateMinCutsFast(int index)
         }
         else
         {
-            min_cuts.remove(idx2);
+            min_cuts.remove_if_exists(idx2);
         }
     }
 }
@@ -136,7 +136,7 @@ void MonotoneBooleanFunction::toRecord(Record &r)
 
 ShortList MonotoneBooleanFunction::getMinCNF()
 {
-    ShortList result;    
+    ShortList result = ShortList();
     for (int i = 0; i < min_cuts.getSize(); i++)
     {
         int element = min_cuts.getValue(i);

--- a/walk.bitstat5/MonotoneBooleanFunction.cpp
+++ b/walk.bitstat5/MonotoneBooleanFunction.cpp
@@ -6,7 +6,7 @@ int hammingDistance(uint64_t x, uint64_t y)
     return std::bitset<64>(x ^ y).count();
 }
 
-MonotoneBooleanFunction::MonotoneBooleanFunction(int dim, std::mt19937 &rng) : dimension(dim), min_cuts(rng), rng(rng), weight(0)
+MonotoneBooleanFunction::MonotoneBooleanFunction(int dim, std::mt19937 &rng) : dimension(dim), min_cuts(), rng(rng), weight(0)
 {
 
     functionArray = new bool[1 << dim](); // Initialize all values to false
@@ -101,7 +101,7 @@ void MonotoneBooleanFunction::updateMinCutsFast(int index)
 
 int MonotoneBooleanFunction::getRandomMinCut() const
 {
-    return min_cuts.getRandomElement();
+    return min_cuts.getRandomElement(rng);
 }
 
 void MonotoneBooleanFunction::printMinCuts() const
@@ -136,7 +136,7 @@ void MonotoneBooleanFunction::toRecord(Record &r)
 
 ShortList *MonotoneBooleanFunction::getMinCNF()
 {
-    ShortList *result = new ShortList(rng);    
+    ShortList *result = new ShortList();    
     for (int i = 0; i < min_cuts.getSize(); i++)
     {
         int element = min_cuts.getValue(i);

--- a/walk.bitstat5/MonotoneBooleanFunction.h
+++ b/walk.bitstat5/MonotoneBooleanFunction.h
@@ -48,7 +48,7 @@ public:
 
     void toRecord(Record &r);
 
-    ShortList *getMinCNF();
+    ShortList getMinCNF();
 
     static int recordHammingDistance(const Record &rec1, const Record &rec2);
 };

--- a/walk.bitstat5/ShortList.cpp
+++ b/walk.bitstat5/ShortList.cpp
@@ -1,6 +1,7 @@
 #include "ShortList.h"
 #include <algorithm> // For std::find
 #include <iostream>
+#include <assert.h>
 
 ShortList::ShortList() : size(0)
 {
@@ -9,23 +10,30 @@ ShortList::ShortList() : size(0)
     std::fill(indexArr, indexArr + MAX_SIZE, -1); // Invalid index
 }
 
-bool ShortList::insert(int num)
+void ShortList::insert(int num)
 {
-    if (size < MAX_SIZE && !contains(num))
-    {
-        arr[size] = num;
-        containsArr[num] = true;
-        indexArr[num] = size;
-        ++size;
-        return true;
-    }
-    return false; // List is full or integer already exists
+    assert(size < MAX_SIZE);
+    assert(!contains(num));
+    
+    arr[size] = num;
+    containsArr[num] = true;
+    indexArr[num] = size;
+    ++size;
 }
 
-bool ShortList::remove(int num)
+void ShortList::remove(int num)
 {
-    if (contains(num))
-    {
+    assert(contains(num));
+    int idx = indexArr[num];
+    arr[idx] = arr[--size];       // Replace the element with the last element and decrement size
+    containsArr[arr[idx]] = true; // Update containsArr for the moved element
+    containsArr[num] = false;
+    indexArr[arr[idx]] = idx; // Update indexArr for the moved element
+    indexArr[num] = -1;       // Invalidate the index of the removed element
+}
+bool ShortList::remove_if_exists(int num)
+{
+    if(contains(num)) {
         int idx = indexArr[num];
         arr[idx] = arr[--size];       // Replace the element with the last element and decrement size
         containsArr[arr[idx]] = true; // Update containsArr for the moved element
@@ -34,7 +42,7 @@ bool ShortList::remove(int num)
         indexArr[num] = -1;       // Invalidate the index of the removed element
         return true;
     }
-    return false; // Element not found
+    return false;
 }
 
 bool ShortList::contains(int num) const
@@ -44,11 +52,8 @@ bool ShortList::contains(int num) const
 
 int ShortList::getRandomElement(std::mt19937 &rng) const
 {
-    if (size > 0)
-    {
-        return arr[rng() % size];
-    }
-    return -1; // No elements in the list
+    assert(size > 0);
+    return arr[rng() % size];
 }
 
 int ShortList::getSize() const
@@ -58,11 +63,9 @@ int ShortList::getSize() const
 
 int ShortList::getValue(int pos) const
 {
-    if (pos >= 0 && pos < size)
-    {
-        return arr[pos];
-    }
-    return -1; // Invalid position
+    assert(pos >= 0 && pos < size);
+    
+    return arr[pos];
 }
 
 void ShortList::print() const

--- a/walk.bitstat5/ShortList.cpp
+++ b/walk.bitstat5/ShortList.cpp
@@ -2,7 +2,7 @@
 #include <algorithm> // For std::find
 #include <iostream>
 
-ShortList::ShortList(std::mt19937 &rng) : size(0), rng(rng)
+ShortList::ShortList() : size(0)
 {
     // Initialize containsArr and indexArr
     std::fill(containsArr, containsArr + MAX_SIZE, false);
@@ -42,7 +42,7 @@ bool ShortList::contains(int num) const
     return num >= 0 && num < MAX_SIZE && containsArr[num];
 }
 
-int ShortList::getRandomElement() const
+int ShortList::getRandomElement(std::mt19937 &rng) const
 {
     if (size > 0)
     {

--- a/walk.bitstat5/ShortList.h
+++ b/walk.bitstat5/ShortList.h
@@ -14,9 +14,12 @@ private:
 public:
     ShortList();
 
-    bool insert(int num);
+    void insert(int num);
 
-    bool remove(int num);
+    void remove(int num);
+
+    // Returns true on success
+    bool remove_if_exists(int num);
 
     bool contains(int num) const;
 

--- a/walk.bitstat5/ShortList.h
+++ b/walk.bitstat5/ShortList.h
@@ -10,10 +10,9 @@ private:
     bool containsArr[MAX_SIZE];       // Array to check contains
     int indexArr[MAX_SIZE];           // Array to store the index of each integer
     int size;                         // Current size of the list
-    std::mt19937 &rng;                // Reference to Mersenne Twister random number generator
 
 public:
-    ShortList(std::mt19937 &rng);
+    ShortList();
 
     bool insert(int num);
 
@@ -21,7 +20,7 @@ public:
 
     bool contains(int num) const;
 
-    int getRandomElement() const;
+    int getRandomElement(std::mt19937 &rng) const;
 
     int getSize() const;
 

--- a/walk.bitstat5/main.cpp
+++ b/walk.bitstat5/main.cpp
@@ -115,28 +115,27 @@ int main()
         int total2 = 0;
         for (int ls = 0; ls < LIST_SIZE; ls++)
         {
-            ShortList *sl = mbfList[ls].getMinCNF();
-            if (sl->getSize() > 0)
+            ShortList sl = mbfList[ls].getMinCNF();
+            if (sl.getSize() > 0)
             {
-                BitStorage result = bitStorage[sl->getValue(0)].clone();
-                for (int i = 1; i < sl->getSize(); i++)
-                    result.bitwiseAnd(bitStorage[sl->getValue(i)]);
+                BitStorage result = bitStorage[sl.getValue(0)].clone();
+                for (int i = 1; i < sl.getSize(); i++)
+                    result.bitwiseAnd(bitStorage[sl.getValue(i)]);
                 total2 += result.countBitsSet();
             }
-            delete sl;
         }
         int64_t time4 = time_ms();
         int total3 = 0;
         for (int ls = 0; ls < LIST_SIZE; ls++)
         {
-            ShortList *sl = mbfList[ls].getMinCNF();
+            ShortList sl = mbfList[ls].getMinCNF();
 
             for (size_t nChunk = 0; nChunk < LIST_SIZE / 512; ++nChunk)
             {
-                __m512i chunk = bitStorage[sl->getValue(0)].getChunk(nChunk);
-                for (int i = 1; i < sl->getSize(); i++)
+                __m512i chunk = bitStorage[sl.getValue(0)].getChunk(nChunk);
+                for (int i = 1; i < sl.getSize(); i++)
                 {
-                    __m512i chunk2 = bitStorage[sl->getValue(i)].getChunk(nChunk);
+                    __m512i chunk2 = bitStorage[sl.getValue(i)].getChunk(nChunk);
                     chunk = _mm512_and_si512(chunk, chunk2);
                 }
                 //__m512i resultChunk = result.getChunk(nChunk);
@@ -146,8 +145,6 @@ int main()
                 // Add the result to the total count
                 total3 += _mm512_reduce_add_epi64(popcnt);
             }
-
-            delete sl;
         }
 
         int64_t time5 = time_ms();

--- a/walk.bitstat5/main.cpp
+++ b/walk.bitstat5/main.cpp
@@ -142,7 +142,7 @@ int main()
                 //__m512i resultChunk = result.getChunk(nChunk);
                 // if (!are_equal(resultChunk, chunk)) std::cout << "not equal" << std::endl;
 
-                __m512i popcnt = _mm512_popcnt_epi64(chunk);
+                __m512i popcnt = popcount512_64(chunk);
                 // Add the result to the total count
                 total3 += _mm512_reduce_add_epi64(popcnt);
             }

--- a/walk.bitstat5/main.cpp
+++ b/walk.bitstat5/main.cpp
@@ -5,9 +5,11 @@
 #include <iomanip>
 #include <chrono>
 #include <immintrin.h> // For AVX-512 intrinsics
+#include <assert.h>
 #include "ShortList.h"
 #include "MonotoneBooleanFunction.h"
 #include "BitStorage.h"
+#include "FastCompare.h"
 
 bool cmp(uint64_t x1, uint64_t x2)
 {
@@ -151,48 +153,28 @@ int main()
         }
 
         int64_t time5 = time_ms();
-        
-        /*std::vector<int16_t> leftIndices;
-        std::vector<size_t> endPoints;
-        endPoints.reserve(LIST_SIZE);
-        for (int ls = 0; ls < LIST_SIZE; ls++)
-        {
-            ShortList sl = mbfList[ls].getMinCNF();
 
-
-        }
-        int total4 = 0;
-        for (int ls = 0; ls < LIST_SIZE; ls++)
-        {
-            ShortList sl = mbfList[ls].getMinCNF();
-
-            for (size_t nChunk = 0; nChunk < LIST_SIZE / 512; ++nChunk)
-            {
-                __m512i chunk = bitStorage[sl.getValue(0)].getChunk(nChunk);
-                for (int i = 1; i < sl.getSize(); i++)
-                {
-                    __m512i chunk2 = bitStorage[sl.getValue(i)].getChunk(nChunk);
-                    chunk = _mm512_and_si512(chunk, chunk2);
-                }
-                //__m512i resultChunk = result.getChunk(nChunk);
-                // if (!are_equal(resultChunk, chunk)) std::cout << "not equal" << std::endl;
-
-                __m512i popcnt = popcount512_64(chunk);
-                // Add the result to the total count
-                total4 += _mm512_reduce_add_epi64(popcnt);
-            }
-        }
-        std::cout << "time6 done" << std::endl;
-        int64_t time6 = time_ms();*/
-
-        std::cout << "total1: " << total1 << " total2: " << total2 << " total3: " << total3// << " total4: " << total4
+        std::cout << "total1: " << total1 << " total2: " << total2 << " total3: " << total3
                   << " gen.time: " << (time1 - time0)
                   << " cmp1 time: " << (time2 - time1)
                   << " translation time: " << (time3 - time2)
                   << " cmp2 time: " << (time4 - time3)
                   << " cmp3 time: " << (time5 - time4)
-                 // << " cmp4 time: " << (time6 - time5)
                   << std::endl;
+
+
+        // Precompute all Left MBF indices first, because we loop through them often. 
+        FastCompare fc = FastCompare(mbfList, LIST_SIZE);
+
+        fc.template countCompareTo<1>(bitStorage);
+        fc.template countCompareTo<2>(bitStorage);
+        fc.template countCompareTo<4>(bitStorage);
+        fc.template countCompareTo<8>(bitStorage);
+        fc.template countCompareTo<16>(bitStorage);
+        fc.template countCompareTo<32>(bitStorage);
+        fc.template countCompareTo<64>(bitStorage);
+        fc.template countCompareTo<128>(bitStorage);
+        fc.template countCompareTo<256>(bitStorage);
         // std::cout << loop << "\t" << total << "\t" << (t1 - t0) << "\t" << (t3 - t2) << std::endl;
     }
 

--- a/walk.bitstat5/main.cpp
+++ b/walk.bitstat5/main.cpp
@@ -120,7 +120,8 @@ int main()
             ShortList sl = mbfList[ls].getMinCNF();
             if (sl.getSize() > 0)
             {
-                BitStorage result = bitStorage[sl.getValue(0)].clone();
+                size_t chosenBitStorage = sl.getValue(0);
+                BitStorage result = bitStorage[chosenBitStorage].clone();
                 for (int i = 1; i < sl.getSize(); i++)
                     result.bitwiseAnd(bitStorage[sl.getValue(i)]);
                 total2 += result.countBitsSet();
@@ -150,6 +151,16 @@ int main()
         }
 
         int64_t time5 = time_ms();
+        
+        /*std::vector<int16_t> leftIndices;
+        std::vector<size_t> endPoints;
+        endPoints.reserve(LIST_SIZE);
+        for (int ls = 0; ls < LIST_SIZE; ls++)
+        {
+            ShortList sl = mbfList[ls].getMinCNF();
+
+
+        }
         int total4 = 0;
         for (int ls = 0; ls < LIST_SIZE; ls++)
         {
@@ -168,18 +179,19 @@ int main()
 
                 __m512i popcnt = popcount512_64(chunk);
                 // Add the result to the total count
-                total3 += _mm512_reduce_add_epi64(popcnt);
+                total4 += _mm512_reduce_add_epi64(popcnt);
             }
         }
-        int64_t time6 = time_ms();
+        std::cout << "time6 done" << std::endl;
+        int64_t time6 = time_ms();*/
 
-        std::cout << "total1: " << total1 << " total2: " << total2 << " total3: " << total3 << " total4: " << total4
+        std::cout << "total1: " << total1 << " total2: " << total2 << " total3: " << total3// << " total4: " << total4
                   << " gen.time: " << (time1 - time0)
                   << " cmp1 time: " << (time2 - time1)
                   << " translation time: " << (time3 - time2)
                   << " cmp2 time: " << (time4 - time3)
                   << " cmp3 time: " << (time5 - time4)
-                  << " cmp4 time: " << (time6 - time5)
+                 // << " cmp4 time: " << (time6 - time5)
                   << std::endl;
         // std::cout << loop << "\t" << total << "\t" << (t1 - t0) << "\t" << (t3 - t2) << std::endl;
     }


### PR DESCRIPTION
I had to make a replacement for _mm512_popcnt_epi64 because Noctua 1 doesn't have that.

These are my initial times after fixing popcount:

total1: 328510 total2: 328510 total3: 328510 gen.time: 2248 cmp1 time: 7684 translation time: 134 cmp2 time: 590 cmp3 time: 1925
total1: 321479 total2: 321479 total3: 321479 gen.time: 2245 cmp1 time: 7676 translation time: 135 cmp2 time: 584 cmp3 time: 1914
total1: 319920 total2: 319920 total3: 319920 gen.time: 2254 cmp1 time: 7695 translation time: 135 cmp2 time: 583 cmp3 time: 1897
total1: 334278 total2: 334278 total3: 334278 gen.time: 2250 cmp1 time: 7753 translation time: 135 cmp2 time: 583 cmp3 time: 1899
total1: 315380 total2: 315380 total3: 315380 gen.time: 2254 cmp1 time: 7739 translation time: 134 cmp2 time: 584 cmp3 time: 1907
total1: 310120 total2: 310120 total3: 310120 gen.time: 2250 cmp1 time: 7742 translation time: 135 cmp2 time: 583 cmp3 time: 1903
total1: 319040 total2: 319040 total3: 319040 gen.time: 2256 cmp1 time: 7747 translation time: 135 cmp2 time: 586 cmp3 time: 1901

I've also made the BitStorage storage aligned to 64 bytes, as per the page size:

total1: 354080 total2: 354080 total3: 354080 gen.time: 2574 cmp1 time: 7698 translation time: 147 cmp2 time: 545 cmp3 time: 1816
total1: 344180 total2: 344180 total3: 344180 gen.time: 2559 cmp1 time: 7715 translation time: 149 cmp2 time: 547 cmp3 time: 1810
total1: 330705 total2: 330705 total3: 330705 gen.time: 2551 cmp1 time: 7617 translation time: 147 cmp2 time: 545 cmp3 time: 1813
total1: 330610 total2: 330610 total3: 330610 gen.time: 2552 cmp1 time: 7620 translation time: 146 cmp2 time: 543 cmp3 time: 1819
total1: 323318 total2: 323318 total3: 323318 gen.time: 2565 cmp1 time: 7604 translation time: 143 cmp2 time: 535 cmp3 time: 1732
total1: 333030 total2: 333030 total3: 333030 gen.time: 2548 cmp1 time: 7632 translation time: 148 cmp2 time: 533 cmp3 time: 1728
total1: 324493 total2: 324493 total3: 324493 gen.time: 2578 cmp1 time: 7703 translation time: 141 cmp2 time: 535 cmp3 time: 1732
total1: 317261 total2: 317261 total3: 317261 gen.time: 2552 cmp1 time: 7690 translation time: 142 cmp2 time: 533 cmp3 time: 1735

Finally, adding my optimized Chunking method cut down the time by another factor of 3 for the optimal ChunkSize of 32 ^-^. But I don't have _mm512_popcount, so for you it might be different still (I hope better)

total1: 344814 total2: 344814 total3: 344814 gen.time: 2512 cmp1 time: 7747 translation time: 147 cmp2 time: 552 cmp3 time: 1847
endPoints.size(): 51200   leftIndices.size(): 2663375
ChunkSize: 1  total: 344814  time: 1720
ChunkSize: 2  total: 344814  time: 1364
ChunkSize: 4  total: 344814  time: 1014
ChunkSize: 8  total: 344814  time: 257
ChunkSize: 16  total: 344814  time: 192
ChunkSize: 32  total: 344814  time: 172
ChunkSize: 64  total: 344814  time: 180
ChunkSize: 128  total: 344814  time: 225
ChunkSize: 256  total: 344814  time: 252
total1: 357112 total2: 357112 total3: 357112 gen.time: 2526 cmp1 time: 7685 translation time: 147 cmp2 time: 549 cmp3 time: 1838
endPoints.size(): 51200   leftIndices.size(): 2659234
ChunkSize: 1  total: 357112  time: 1702
ChunkSize: 2  total: 357112  time: 1364
ChunkSize: 4  total: 357112  time: 1013
ChunkSize: 8  total: 357112  time: 257
ChunkSize: 16  total: 357112  time: 191
ChunkSize: 32  total: 357112  time: 172
ChunkSize: 64  total: 357112  time: 179
ChunkSize: 128  total: 357112  time: 226
ChunkSize: 256  total: 357112  time: 251
total1: 340677 total2: 340677 total3: 340677 gen.time: 2521 cmp1 time: 7752 translation time: 147 cmp2 time: 548 cmp3 time: 1835
endPoints.size(): 51200   leftIndices.size(): 2658448
ChunkSize: 1  total: 340677  time: 1700
ChunkSize: 2  total: 340677  time: 1361
ChunkSize: 4  total: 340677  time: 1013
ChunkSize: 8  total: 340677  time: 256
ChunkSize: 16  total: 340677  time: 191
ChunkSize: 32  total: 340677  time: 172
ChunkSize: 64  total: 340677  time: 179
ChunkSize: 128  total: 340677  time: 225
ChunkSize: 256  total: 340677  time: 248

It appears ChunkSize 32 is best, which corresponds to 4 AVX512 registers.

Calculating the amount of memory that needs to be in cache per chunk, that comes down to 256 bytes * 512 = 131KB.

My Cache sizes are:
L1d cache:           32K
L1i cache:           32K
L2 cache:            1024K
L3 cache:            28160K

So likely because only about a quarter of the bitsets are actually "heavily used", I'm guessing in this case it's limited by L1 cache size.